### PR TITLE
Add unit tests for ScreenInfoTextParser

### DIFF
--- a/screenChecker/build.gradle.kts
+++ b/screenChecker/build.gradle.kts
@@ -41,6 +41,7 @@ dependencies {
     implementation("androidx.annotation:annotation:1.9.1")
     implementation("androidx.activity:activity-ktx:1.9.3")
     testImplementation("junit:junit:4.13.2")
+    testImplementation("io.kotest:kotest-assertions-core:5.9.1")
     androidTestImplementation("androidx.test.ext:junit:1.2.1")
     androidTestImplementation("androidx.test.espresso:espresso-core:3.6.1")
 }

--- a/screenChecker/src/test/java/com/akexorcist/screenchecker/ScreenInfoTextParserTest.kt
+++ b/screenChecker/src/test/java/com/akexorcist/screenchecker/ScreenInfoTextParserTest.kt
@@ -1,0 +1,269 @@
+package com.akexorcist.screenchecker
+
+import android.content.res.Configuration
+import android.util.DisplayMetrics
+import android.view.Surface
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class ScreenInfoTextParserTest {
+    private val lineSeparator = System.lineSeparator()
+
+    // region size()
+    @Test
+    fun `size maps known screen layout size constants`() {
+        assertEquals("Small", ScreenInfoTextParser.size(Configuration.SCREENLAYOUT_SIZE_SMALL))
+        assertEquals("Normal", ScreenInfoTextParser.size(Configuration.SCREENLAYOUT_SIZE_NORMAL))
+        assertEquals("Large", ScreenInfoTextParser.size(Configuration.SCREENLAYOUT_SIZE_LARGE))
+        assertEquals("Extra Large", ScreenInfoTextParser.size(Configuration.SCREENLAYOUT_SIZE_XLARGE))
+        assertEquals("Undefined", ScreenInfoTextParser.size(Configuration.SCREENLAYOUT_SIZE_UNDEFINED))
+    }
+
+    @Test
+    fun `size falls back to Unknown for unrecognized value`() {
+        assertEquals("Unknown", ScreenInfoTextParser.size(9999))
+    }
+    // endregion
+
+    // region density()
+    @Test
+    fun `density maps known density buckets`() {
+        assertEquals("Low", ScreenInfoTextParser.density(DisplayMetrics.DENSITY_LOW))
+        assertEquals("Medium", ScreenInfoTextParser.density(DisplayMetrics.DENSITY_MEDIUM))
+        assertEquals("High", ScreenInfoTextParser.density(DisplayMetrics.DENSITY_HIGH))
+        assertEquals("Extra High", ScreenInfoTextParser.density(DisplayMetrics.DENSITY_XHIGH))
+        assertEquals("Extra Extra High", ScreenInfoTextParser.density(DisplayMetrics.DENSITY_XXHIGH))
+        assertEquals("Extra Extra Extra High", ScreenInfoTextParser.density(DisplayMetrics.DENSITY_XXXHIGH))
+        assertEquals("TV", ScreenInfoTextParser.density(DisplayMetrics.DENSITY_TV))
+        assertEquals("Density 420", ScreenInfoTextParser.density(DisplayMetrics.DENSITY_420))
+    }
+
+    @Test
+    fun `density falls back to Unknown Density with the raw value for unrecognized dpi`() {
+        assertEquals("Unknown Density (123)", ScreenInfoTextParser.density(123))
+    }
+    // endregion
+
+    // region rotation()
+    @Test
+    fun `rotation maps known surface rotation constants to degrees`() {
+        assertEquals("0°", ScreenInfoTextParser.rotation(Surface.ROTATION_0))
+        assertEquals("90°", ScreenInfoTextParser.rotation(Surface.ROTATION_90))
+        assertEquals("180°", ScreenInfoTextParser.rotation(Surface.ROTATION_180))
+        assertEquals("270°", ScreenInfoTextParser.rotation(Surface.ROTATION_270))
+    }
+
+    @Test
+    fun `rotation falls back to Unknown Rotation for unrecognized value`() {
+        assertEquals("Unknown Rotation", ScreenInfoTextParser.rotation(42))
+    }
+    // endregion
+
+    // region layout()
+    @Test
+    fun `layout maps known screen layout long constants`() {
+        assertEquals("Long", ScreenInfoTextParser.layout(Configuration.SCREENLAYOUT_LONG_YES))
+        assertEquals("Not Long", ScreenInfoTextParser.layout(Configuration.SCREENLAYOUT_LONG_NO))
+        assertEquals("Undefined", ScreenInfoTextParser.layout(Configuration.SCREENLAYOUT_LONG_UNDEFINED))
+    }
+
+    @Test
+    fun `layout falls back to Unknown for unrecognized value`() {
+        assertEquals("Unknown", ScreenInfoTextParser.layout(9999))
+    }
+    // endregion
+
+    // region colorMode()
+    @Test
+    fun `colorMode reports Not supported when no flags are set`() {
+        val colorMode = ColorMode(hdr = false, wideColorGamut = false, hdrSdrRatio = false)
+        assertEquals("Not supported", ScreenInfoTextParser.colorMode(colorMode))
+    }
+
+    @Test
+    fun `colorMode reports a single flag`() {
+        assertEquals(
+            "HDR",
+            ScreenInfoTextParser.colorMode(ColorMode(hdr = true, wideColorGamut = false, hdrSdrRatio = false)),
+        )
+        assertEquals(
+            "Wide Color Gamut",
+            ScreenInfoTextParser.colorMode(ColorMode(hdr = false, wideColorGamut = true, hdrSdrRatio = false)),
+        )
+        assertEquals(
+            "HDR/SDR",
+            ScreenInfoTextParser.colorMode(ColorMode(hdr = false, wideColorGamut = false, hdrSdrRatio = true)),
+        )
+    }
+
+    @Test
+    fun `colorMode joins all flags in declaration order separated by newlines`() {
+        val colorMode = ColorMode(hdr = true, wideColorGamut = true, hdrSdrRatio = true)
+        val expected = listOf("HDR", "Wide Color Gamut", "HDR/SDR").joinToString(lineSeparator)
+        assertEquals(expected, ScreenInfoTextParser.colorMode(colorMode))
+    }
+    // endregion
+
+    // region multitouch()
+    @Test
+    fun `multitouch maps known multitouch levels`() {
+        assertEquals("5+ Points", ScreenInfoTextParser.multitouch(Multitouch.JAZZHAND))
+        assertEquals("2-5 Points", ScreenInfoTextParser.multitouch(Multitouch.DISTINCT))
+        assertEquals("2 Points", ScreenInfoTextParser.multitouch(Multitouch.SIMPLE))
+    }
+
+    @Test
+    fun `multitouch reports Not supported for unsupported and unrecognized values`() {
+        assertEquals("Not supported", ScreenInfoTextParser.multitouch(Multitouch.UNSUPPORTED))
+        assertEquals("Not supported", ScreenInfoTextParser.multitouch(999))
+    }
+    // endregion
+
+    // region uiMode()
+    @Test
+    fun `uiMode maps known ui mode types without night flag`() {
+        assertEquals(
+            "Normal",
+            ScreenInfoTextParser.uiMode(UiMode(Configuration.UI_MODE_TYPE_NORMAL, Configuration.UI_MODE_NIGHT_NO)),
+        )
+        assertEquals(
+            "Car",
+            ScreenInfoTextParser.uiMode(UiMode(Configuration.UI_MODE_TYPE_CAR, Configuration.UI_MODE_NIGHT_NO)),
+        )
+        assertEquals(
+            "Desk",
+            ScreenInfoTextParser.uiMode(UiMode(Configuration.UI_MODE_TYPE_DESK, Configuration.UI_MODE_NIGHT_NO)),
+        )
+        assertEquals(
+            "Television",
+            ScreenInfoTextParser.uiMode(UiMode(Configuration.UI_MODE_TYPE_TELEVISION, Configuration.UI_MODE_NIGHT_NO)),
+        )
+        assertEquals(
+            "Watch",
+            ScreenInfoTextParser.uiMode(UiMode(Configuration.UI_MODE_TYPE_WATCH, Configuration.UI_MODE_NIGHT_NO)),
+        )
+        assertEquals(
+            "Appliance",
+            ScreenInfoTextParser.uiMode(UiMode(Configuration.UI_MODE_TYPE_APPLIANCE, Configuration.UI_MODE_NIGHT_NO)),
+        )
+        assertEquals(
+            "VR Headset",
+            ScreenInfoTextParser.uiMode(UiMode(Configuration.UI_MODE_TYPE_VR_HEADSET, Configuration.UI_MODE_NIGHT_NO)),
+        )
+    }
+
+    @Test
+    fun `uiMode falls back to Unknown for an unrecognized type`() {
+        assertEquals("Unknown", ScreenInfoTextParser.uiMode(UiMode(9999, Configuration.UI_MODE_NIGHT_NO)))
+    }
+
+    @Test
+    fun `uiMode appends with Night suffix when night mode is active`() {
+        assertEquals(
+            "Normal with Night",
+            ScreenInfoTextParser.uiMode(UiMode(Configuration.UI_MODE_TYPE_NORMAL, Configuration.UI_MODE_NIGHT_YES)),
+        )
+    }
+    // endregion
+
+    // region resolutionDp() / resolutionPx()
+    @Test
+    fun `resolutionDp formats width and height with dp suffix`() {
+        assertEquals("1080 x 1920 dp", ScreenInfoTextParser.resolutionDp(Resolution(1080, 1920)))
+    }
+
+    @Test
+    fun `resolutionPx formats width and height with px suffix`() {
+        assertEquals("1080 x 1920 px", ScreenInfoTextParser.resolutionPx(Resolution(1080, 1920)))
+    }
+    // endregion
+
+    // region dpi()
+    @Test
+    fun `dpi formats the value with a DPI suffix`() {
+        assertEquals("420 DPI", ScreenInfoTextParser.dpi(420))
+    }
+    // endregion
+
+    // region hdrType()
+    @Test
+    fun `hdrType reports Not supported for null input`() {
+        assertEquals("Not supported", ScreenInfoTextParser.hdrType(null))
+    }
+
+    @Test
+    fun `hdrType reports Not supported when no flags are set`() {
+        val hdrType = HdrType(dolbyVision = false, hdr10 = false, hdr10Plus = false, hlg = false)
+        assertEquals("Not supported", ScreenInfoTextParser.hdrType(hdrType))
+    }
+
+    @Test
+    fun `hdrType joins all supported flags in declaration order separated by newlines`() {
+        val hdrType = HdrType(dolbyVision = true, hdr10 = true, hdr10Plus = true, hlg = true)
+        val expected = listOf("Dolby Vision", "HDR10", "HDR10+", "HLG").joinToString(lineSeparator)
+        assertEquals(expected, ScreenInfoTextParser.hdrType(hdrType))
+    }
+
+    @Test
+    fun `hdrType reports a single flag`() {
+        assertEquals(
+            "HDR10+",
+            ScreenInfoTextParser.hdrType(HdrType(dolbyVision = false, hdr10 = false, hdr10Plus = true, hlg = false)),
+        )
+    }
+    // endregion
+
+    // region currentDisplay()
+    @Test
+    fun `currentDisplay falls back to Unknown Name when name is null and omits absent fields`() {
+        val displayInfo = DisplayInfo(name = null, mode = null, rotation = Surface.ROTATION_0, colorSpace = null)
+        assertEquals("Unknown Name", ScreenInfoTextParser.currentDisplay(displayInfo))
+    }
+
+    @Test
+    fun `currentDisplay omits blank color space`() {
+        val displayInfo = DisplayInfo(name = "Built-in Screen", mode = null, rotation = Surface.ROTATION_0, colorSpace = "")
+        assertEquals("Built-in Screen", ScreenInfoTextParser.currentDisplay(displayInfo))
+    }
+
+    @Test
+    fun `currentDisplay includes name, color space and mode when all present`() {
+        val mode = DisplayMode(id = 1, refreshRate = 60, width = 1080, height = 1920)
+        val displayInfo = DisplayInfo(
+            name = "Built-in Screen",
+            mode = mode,
+            rotation = Surface.ROTATION_0,
+            colorSpace = "DCI-P3",
+        )
+        val expected = listOf(
+            "Built-in Screen",
+            "DCI-P3",
+            "(1) 1080 x 1920${lineSeparator}60Hz",
+        ).joinToString(lineSeparator)
+        assertEquals(expected, ScreenInfoTextParser.currentDisplay(displayInfo))
+    }
+    // endregion
+
+    // region supportedDisplayMode()
+    @Test
+    fun `supportedDisplayMode reports Unknown for an empty list`() {
+        assertEquals("Unknown", ScreenInfoTextParser.supportedDisplayMode(emptyList()))
+    }
+
+    @Test
+    fun `supportedDisplayMode formats a single mode`() {
+        val modes = listOf(DisplayMode(id = 0, refreshRate = 60, width = 1080, height = 1920))
+        assertEquals("(0) 1080 x 1920${lineSeparator}60Hz", ScreenInfoTextParser.supportedDisplayMode(modes))
+    }
+
+    @Test
+    fun `supportedDisplayMode joins multiple modes with a blank line between them`() {
+        val modes = listOf(
+            DisplayMode(id = 0, refreshRate = 60, width = 1080, height = 1920),
+            DisplayMode(id = 1, refreshRate = 120, width = 1080, height = 1920),
+        )
+        val expected = "(0) 1080 x 1920${lineSeparator}60Hz$lineSeparator$lineSeparator(1) 1080 x 1920${lineSeparator}120Hz"
+        assertEquals(expected, ScreenInfoTextParser.supportedDisplayMode(modes))
+    }
+    // endregion
+}

--- a/screenChecker/src/test/java/com/akexorcist/screenchecker/ScreenInfoTextParserTest.kt
+++ b/screenChecker/src/test/java/com/akexorcist/screenchecker/ScreenInfoTextParserTest.kt
@@ -3,7 +3,7 @@ package com.akexorcist.screenchecker
 import android.content.res.Configuration
 import android.util.DisplayMetrics
 import android.view.Surface
-import org.junit.Assert.assertEquals
+import io.kotest.matchers.shouldBe
 import org.junit.Test
 
 class ScreenInfoTextParserTest {
@@ -12,64 +12,64 @@ class ScreenInfoTextParserTest {
     // region size()
     @Test
     fun `size maps known screen layout size constants`() {
-        assertEquals("Small", ScreenInfoTextParser.size(Configuration.SCREENLAYOUT_SIZE_SMALL))
-        assertEquals("Normal", ScreenInfoTextParser.size(Configuration.SCREENLAYOUT_SIZE_NORMAL))
-        assertEquals("Large", ScreenInfoTextParser.size(Configuration.SCREENLAYOUT_SIZE_LARGE))
-        assertEquals("Extra Large", ScreenInfoTextParser.size(Configuration.SCREENLAYOUT_SIZE_XLARGE))
-        assertEquals("Undefined", ScreenInfoTextParser.size(Configuration.SCREENLAYOUT_SIZE_UNDEFINED))
+        ScreenInfoTextParser.size(Configuration.SCREENLAYOUT_SIZE_SMALL) shouldBe "Small"
+        ScreenInfoTextParser.size(Configuration.SCREENLAYOUT_SIZE_NORMAL) shouldBe "Normal"
+        ScreenInfoTextParser.size(Configuration.SCREENLAYOUT_SIZE_LARGE) shouldBe "Large"
+        ScreenInfoTextParser.size(Configuration.SCREENLAYOUT_SIZE_XLARGE) shouldBe "Extra Large"
+        ScreenInfoTextParser.size(Configuration.SCREENLAYOUT_SIZE_UNDEFINED) shouldBe "Undefined"
     }
 
     @Test
     fun `size falls back to Unknown for unrecognized value`() {
-        assertEquals("Unknown", ScreenInfoTextParser.size(9999))
+        ScreenInfoTextParser.size(9999) shouldBe "Unknown"
     }
     // endregion
 
     // region density()
     @Test
     fun `density maps known density buckets`() {
-        assertEquals("Low", ScreenInfoTextParser.density(DisplayMetrics.DENSITY_LOW))
-        assertEquals("Medium", ScreenInfoTextParser.density(DisplayMetrics.DENSITY_MEDIUM))
-        assertEquals("High", ScreenInfoTextParser.density(DisplayMetrics.DENSITY_HIGH))
-        assertEquals("Extra High", ScreenInfoTextParser.density(DisplayMetrics.DENSITY_XHIGH))
-        assertEquals("Extra Extra High", ScreenInfoTextParser.density(DisplayMetrics.DENSITY_XXHIGH))
-        assertEquals("Extra Extra Extra High", ScreenInfoTextParser.density(DisplayMetrics.DENSITY_XXXHIGH))
-        assertEquals("TV", ScreenInfoTextParser.density(DisplayMetrics.DENSITY_TV))
-        assertEquals("Density 420", ScreenInfoTextParser.density(DisplayMetrics.DENSITY_420))
+        ScreenInfoTextParser.density(DisplayMetrics.DENSITY_LOW) shouldBe "Low"
+        ScreenInfoTextParser.density(DisplayMetrics.DENSITY_MEDIUM) shouldBe "Medium"
+        ScreenInfoTextParser.density(DisplayMetrics.DENSITY_HIGH) shouldBe "High"
+        ScreenInfoTextParser.density(DisplayMetrics.DENSITY_XHIGH) shouldBe "Extra High"
+        ScreenInfoTextParser.density(DisplayMetrics.DENSITY_XXHIGH) shouldBe "Extra Extra High"
+        ScreenInfoTextParser.density(DisplayMetrics.DENSITY_XXXHIGH) shouldBe "Extra Extra Extra High"
+        ScreenInfoTextParser.density(DisplayMetrics.DENSITY_TV) shouldBe "TV"
+        ScreenInfoTextParser.density(DisplayMetrics.DENSITY_420) shouldBe "Density 420"
     }
 
     @Test
     fun `density falls back to Unknown Density with the raw value for unrecognized dpi`() {
-        assertEquals("Unknown Density (123)", ScreenInfoTextParser.density(123))
+        ScreenInfoTextParser.density(123) shouldBe "Unknown Density (123)"
     }
     // endregion
 
     // region rotation()
     @Test
     fun `rotation maps known surface rotation constants to degrees`() {
-        assertEquals("0°", ScreenInfoTextParser.rotation(Surface.ROTATION_0))
-        assertEquals("90°", ScreenInfoTextParser.rotation(Surface.ROTATION_90))
-        assertEquals("180°", ScreenInfoTextParser.rotation(Surface.ROTATION_180))
-        assertEquals("270°", ScreenInfoTextParser.rotation(Surface.ROTATION_270))
+        ScreenInfoTextParser.rotation(Surface.ROTATION_0) shouldBe "0°"
+        ScreenInfoTextParser.rotation(Surface.ROTATION_90) shouldBe "90°"
+        ScreenInfoTextParser.rotation(Surface.ROTATION_180) shouldBe "180°"
+        ScreenInfoTextParser.rotation(Surface.ROTATION_270) shouldBe "270°"
     }
 
     @Test
     fun `rotation falls back to Unknown Rotation for unrecognized value`() {
-        assertEquals("Unknown Rotation", ScreenInfoTextParser.rotation(42))
+        ScreenInfoTextParser.rotation(42) shouldBe "Unknown Rotation"
     }
     // endregion
 
     // region layout()
     @Test
     fun `layout maps known screen layout long constants`() {
-        assertEquals("Long", ScreenInfoTextParser.layout(Configuration.SCREENLAYOUT_LONG_YES))
-        assertEquals("Not Long", ScreenInfoTextParser.layout(Configuration.SCREENLAYOUT_LONG_NO))
-        assertEquals("Undefined", ScreenInfoTextParser.layout(Configuration.SCREENLAYOUT_LONG_UNDEFINED))
+        ScreenInfoTextParser.layout(Configuration.SCREENLAYOUT_LONG_YES) shouldBe "Long"
+        ScreenInfoTextParser.layout(Configuration.SCREENLAYOUT_LONG_NO) shouldBe "Not Long"
+        ScreenInfoTextParser.layout(Configuration.SCREENLAYOUT_LONG_UNDEFINED) shouldBe "Undefined"
     }
 
     @Test
     fun `layout falls back to Unknown for unrecognized value`() {
-        assertEquals("Unknown", ScreenInfoTextParser.layout(9999))
+        ScreenInfoTextParser.layout(9999) shouldBe "Unknown"
     }
     // endregion
 
@@ -77,139 +77,127 @@ class ScreenInfoTextParserTest {
     @Test
     fun `colorMode reports Not supported when no flags are set`() {
         val colorMode = ColorMode(hdr = false, wideColorGamut = false, hdrSdrRatio = false)
-        assertEquals("Not supported", ScreenInfoTextParser.colorMode(colorMode))
+        ScreenInfoTextParser.colorMode(colorMode) shouldBe "Not supported"
     }
 
     @Test
     fun `colorMode reports a single flag`() {
-        assertEquals(
-            "HDR",
-            ScreenInfoTextParser.colorMode(ColorMode(hdr = true, wideColorGamut = false, hdrSdrRatio = false)),
-        )
-        assertEquals(
-            "Wide Color Gamut",
-            ScreenInfoTextParser.colorMode(ColorMode(hdr = false, wideColorGamut = true, hdrSdrRatio = false)),
-        )
-        assertEquals(
-            "HDR/SDR",
-            ScreenInfoTextParser.colorMode(ColorMode(hdr = false, wideColorGamut = false, hdrSdrRatio = true)),
-        )
+        ScreenInfoTextParser.colorMode(
+            ColorMode(hdr = true, wideColorGamut = false, hdrSdrRatio = false),
+        ) shouldBe "HDR"
+        ScreenInfoTextParser.colorMode(
+            ColorMode(hdr = false, wideColorGamut = true, hdrSdrRatio = false),
+        ) shouldBe "Wide Color Gamut"
+        ScreenInfoTextParser.colorMode(
+            ColorMode(hdr = false, wideColorGamut = false, hdrSdrRatio = true),
+        ) shouldBe "HDR/SDR"
     }
 
     @Test
     fun `colorMode joins all flags in declaration order separated by newlines`() {
         val colorMode = ColorMode(hdr = true, wideColorGamut = true, hdrSdrRatio = true)
         val expected = listOf("HDR", "Wide Color Gamut", "HDR/SDR").joinToString(lineSeparator)
-        assertEquals(expected, ScreenInfoTextParser.colorMode(colorMode))
+        ScreenInfoTextParser.colorMode(colorMode) shouldBe expected
     }
     // endregion
 
     // region multitouch()
     @Test
     fun `multitouch maps known multitouch levels`() {
-        assertEquals("5+ Points", ScreenInfoTextParser.multitouch(Multitouch.JAZZHAND))
-        assertEquals("2-5 Points", ScreenInfoTextParser.multitouch(Multitouch.DISTINCT))
-        assertEquals("2 Points", ScreenInfoTextParser.multitouch(Multitouch.SIMPLE))
+        ScreenInfoTextParser.multitouch(Multitouch.JAZZHAND) shouldBe "5+ Points"
+        ScreenInfoTextParser.multitouch(Multitouch.DISTINCT) shouldBe "2-5 Points"
+        ScreenInfoTextParser.multitouch(Multitouch.SIMPLE) shouldBe "2 Points"
     }
 
     @Test
     fun `multitouch reports Not supported for unsupported and unrecognized values`() {
-        assertEquals("Not supported", ScreenInfoTextParser.multitouch(Multitouch.UNSUPPORTED))
-        assertEquals("Not supported", ScreenInfoTextParser.multitouch(999))
+        ScreenInfoTextParser.multitouch(Multitouch.UNSUPPORTED) shouldBe "Not supported"
+        ScreenInfoTextParser.multitouch(999) shouldBe "Not supported"
     }
     // endregion
 
     // region uiMode()
     @Test
     fun `uiMode maps known ui mode types without night flag`() {
-        assertEquals(
-            "Normal",
-            ScreenInfoTextParser.uiMode(UiMode(Configuration.UI_MODE_TYPE_NORMAL, Configuration.UI_MODE_NIGHT_NO)),
-        )
-        assertEquals(
-            "Car",
-            ScreenInfoTextParser.uiMode(UiMode(Configuration.UI_MODE_TYPE_CAR, Configuration.UI_MODE_NIGHT_NO)),
-        )
-        assertEquals(
-            "Desk",
-            ScreenInfoTextParser.uiMode(UiMode(Configuration.UI_MODE_TYPE_DESK, Configuration.UI_MODE_NIGHT_NO)),
-        )
-        assertEquals(
-            "Television",
-            ScreenInfoTextParser.uiMode(UiMode(Configuration.UI_MODE_TYPE_TELEVISION, Configuration.UI_MODE_NIGHT_NO)),
-        )
-        assertEquals(
-            "Watch",
-            ScreenInfoTextParser.uiMode(UiMode(Configuration.UI_MODE_TYPE_WATCH, Configuration.UI_MODE_NIGHT_NO)),
-        )
-        assertEquals(
-            "Appliance",
-            ScreenInfoTextParser.uiMode(UiMode(Configuration.UI_MODE_TYPE_APPLIANCE, Configuration.UI_MODE_NIGHT_NO)),
-        )
-        assertEquals(
-            "VR Headset",
-            ScreenInfoTextParser.uiMode(UiMode(Configuration.UI_MODE_TYPE_VR_HEADSET, Configuration.UI_MODE_NIGHT_NO)),
-        )
+        ScreenInfoTextParser.uiMode(
+            UiMode(Configuration.UI_MODE_TYPE_NORMAL, Configuration.UI_MODE_NIGHT_NO),
+        ) shouldBe "Normal"
+        ScreenInfoTextParser.uiMode(
+            UiMode(Configuration.UI_MODE_TYPE_CAR, Configuration.UI_MODE_NIGHT_NO),
+        ) shouldBe "Car"
+        ScreenInfoTextParser.uiMode(
+            UiMode(Configuration.UI_MODE_TYPE_DESK, Configuration.UI_MODE_NIGHT_NO),
+        ) shouldBe "Desk"
+        ScreenInfoTextParser.uiMode(
+            UiMode(Configuration.UI_MODE_TYPE_TELEVISION, Configuration.UI_MODE_NIGHT_NO),
+        ) shouldBe "Television"
+        ScreenInfoTextParser.uiMode(
+            UiMode(Configuration.UI_MODE_TYPE_WATCH, Configuration.UI_MODE_NIGHT_NO),
+        ) shouldBe "Watch"
+        ScreenInfoTextParser.uiMode(
+            UiMode(Configuration.UI_MODE_TYPE_APPLIANCE, Configuration.UI_MODE_NIGHT_NO),
+        ) shouldBe "Appliance"
+        ScreenInfoTextParser.uiMode(
+            UiMode(Configuration.UI_MODE_TYPE_VR_HEADSET, Configuration.UI_MODE_NIGHT_NO),
+        ) shouldBe "VR Headset"
     }
 
     @Test
     fun `uiMode falls back to Unknown for an unrecognized type`() {
-        assertEquals("Unknown", ScreenInfoTextParser.uiMode(UiMode(9999, Configuration.UI_MODE_NIGHT_NO)))
+        ScreenInfoTextParser.uiMode(UiMode(9999, Configuration.UI_MODE_NIGHT_NO)) shouldBe "Unknown"
     }
 
     @Test
     fun `uiMode appends with Night suffix when night mode is active`() {
-        assertEquals(
-            "Normal with Night",
-            ScreenInfoTextParser.uiMode(UiMode(Configuration.UI_MODE_TYPE_NORMAL, Configuration.UI_MODE_NIGHT_YES)),
-        )
+        ScreenInfoTextParser.uiMode(
+            UiMode(Configuration.UI_MODE_TYPE_NORMAL, Configuration.UI_MODE_NIGHT_YES),
+        ) shouldBe "Normal with Night"
     }
     // endregion
 
     // region resolutionDp() / resolutionPx()
     @Test
     fun `resolutionDp formats width and height with dp suffix`() {
-        assertEquals("1080 x 1920 dp", ScreenInfoTextParser.resolutionDp(Resolution(1080, 1920)))
+        ScreenInfoTextParser.resolutionDp(Resolution(1080, 1920)) shouldBe "1080 x 1920 dp"
     }
 
     @Test
     fun `resolutionPx formats width and height with px suffix`() {
-        assertEquals("1080 x 1920 px", ScreenInfoTextParser.resolutionPx(Resolution(1080, 1920)))
+        ScreenInfoTextParser.resolutionPx(Resolution(1080, 1920)) shouldBe "1080 x 1920 px"
     }
     // endregion
 
     // region dpi()
     @Test
     fun `dpi formats the value with a DPI suffix`() {
-        assertEquals("420 DPI", ScreenInfoTextParser.dpi(420))
+        ScreenInfoTextParser.dpi(420) shouldBe "420 DPI"
     }
     // endregion
 
     // region hdrType()
     @Test
     fun `hdrType reports Not supported for null input`() {
-        assertEquals("Not supported", ScreenInfoTextParser.hdrType(null))
+        ScreenInfoTextParser.hdrType(null) shouldBe "Not supported"
     }
 
     @Test
     fun `hdrType reports Not supported when no flags are set`() {
         val hdrType = HdrType(dolbyVision = false, hdr10 = false, hdr10Plus = false, hlg = false)
-        assertEquals("Not supported", ScreenInfoTextParser.hdrType(hdrType))
+        ScreenInfoTextParser.hdrType(hdrType) shouldBe "Not supported"
     }
 
     @Test
     fun `hdrType joins all supported flags in declaration order separated by newlines`() {
         val hdrType = HdrType(dolbyVision = true, hdr10 = true, hdr10Plus = true, hlg = true)
         val expected = listOf("Dolby Vision", "HDR10", "HDR10+", "HLG").joinToString(lineSeparator)
-        assertEquals(expected, ScreenInfoTextParser.hdrType(hdrType))
+        ScreenInfoTextParser.hdrType(hdrType) shouldBe expected
     }
 
     @Test
     fun `hdrType reports a single flag`() {
-        assertEquals(
-            "HDR10+",
-            ScreenInfoTextParser.hdrType(HdrType(dolbyVision = false, hdr10 = false, hdr10Plus = true, hlg = false)),
-        )
+        ScreenInfoTextParser.hdrType(
+            HdrType(dolbyVision = false, hdr10 = false, hdr10Plus = true, hlg = false),
+        ) shouldBe "HDR10+"
     }
     // endregion
 
@@ -217,13 +205,13 @@ class ScreenInfoTextParserTest {
     @Test
     fun `currentDisplay falls back to Unknown Name when name is null and omits absent fields`() {
         val displayInfo = DisplayInfo(name = null, mode = null, rotation = Surface.ROTATION_0, colorSpace = null)
-        assertEquals("Unknown Name", ScreenInfoTextParser.currentDisplay(displayInfo))
+        ScreenInfoTextParser.currentDisplay(displayInfo) shouldBe "Unknown Name"
     }
 
     @Test
     fun `currentDisplay omits blank color space`() {
         val displayInfo = DisplayInfo(name = "Built-in Screen", mode = null, rotation = Surface.ROTATION_0, colorSpace = "")
-        assertEquals("Built-in Screen", ScreenInfoTextParser.currentDisplay(displayInfo))
+        ScreenInfoTextParser.currentDisplay(displayInfo) shouldBe "Built-in Screen"
     }
 
     @Test
@@ -240,20 +228,20 @@ class ScreenInfoTextParserTest {
             "DCI-P3",
             "(1) 1080 x 1920${lineSeparator}60Hz",
         ).joinToString(lineSeparator)
-        assertEquals(expected, ScreenInfoTextParser.currentDisplay(displayInfo))
+        ScreenInfoTextParser.currentDisplay(displayInfo) shouldBe expected
     }
     // endregion
 
     // region supportedDisplayMode()
     @Test
     fun `supportedDisplayMode reports Unknown for an empty list`() {
-        assertEquals("Unknown", ScreenInfoTextParser.supportedDisplayMode(emptyList()))
+        ScreenInfoTextParser.supportedDisplayMode(emptyList()) shouldBe "Unknown"
     }
 
     @Test
     fun `supportedDisplayMode formats a single mode`() {
         val modes = listOf(DisplayMode(id = 0, refreshRate = 60, width = 1080, height = 1920))
-        assertEquals("(0) 1080 x 1920${lineSeparator}60Hz", ScreenInfoTextParser.supportedDisplayMode(modes))
+        ScreenInfoTextParser.supportedDisplayMode(modes) shouldBe "(0) 1080 x 1920${lineSeparator}60Hz"
     }
 
     @Test
@@ -263,7 +251,7 @@ class ScreenInfoTextParserTest {
             DisplayMode(id = 1, refreshRate = 120, width = 1080, height = 1920),
         )
         val expected = "(0) 1080 x 1920${lineSeparator}60Hz$lineSeparator$lineSeparator(1) 1080 x 1920${lineSeparator}120Hz"
-        assertEquals(expected, ScreenInfoTextParser.supportedDisplayMode(modes))
+        ScreenInfoTextParser.supportedDisplayMode(modes) shouldBe expected
     }
     // endregion
 }


### PR DESCRIPTION
## Summary
- Adds unit tests covering every formatting/mapping branch in `ScreenInfoTextParser` (known-constant mappings, unknown-value fallbacks, flag-combination joins for `colorMode`/`hdrType`, and the resolution/display/mode string formatters).
- Scoped to `ScreenInfoTextParser` only — it's the sole framework-free pure logic in the library module. `ScreenUtility` and `ScreenCheckerActivity` depend directly on Android framework classes (`Activity`, `Display`, `DisplayManager`) and would need mocking/Robolectric, which was intentionally left out of this pass.

## Test plan
- [x] `./gradlew testDebugUnitTest` — 29/29 pass
- [ ] Note: `testReleaseUnitTest` is not meaningful here since the `release` build type is minified (R8), which strips the class under test; use `testDebugUnitTest` going forward.

🤖 Generated with [Claude Code](https://claude.com/claude-code)