### PR TITLE
Rename PR workflow jobs and add UI Test job

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -5,7 +5,8 @@ on:
     branches: [ "main" ]
 
 jobs:
-  build:
+  compile-check:
+    name: Compile Check
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -23,7 +24,8 @@ jobs:
       - name: Compile Kotlin sources
         run: ./gradlew :app:compileDebugKotlin
 
-  test:
+  unit-test:
+    name: Unit Test
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -40,3 +42,33 @@ jobs:
 
       - name: Run unit tests
         run: ./gradlew testDebugUnitTest
+
+  ui-test:
+    name: UI Test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
+        with:
+          java-version: '21'
+          distribution: 'corretto'
+          cache: gradle
+
+      - name: Grant execute permission for gradlew
+        run: chmod +x gradlew
+
+      - name: Enable KVM group perms
+        run: |
+          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+          sudo udevadm control --reload-rules
+          sudo udevadm trigger --name-match=kvm
+
+      - name: Run UI tests
+        uses: reactivecircus/android-emulator-runner@v2
+        with:
+          api-level: 35
+          target: aosp_atd
+          arch: x86_64
+          script: ./gradlew :screenChecker:connectedDebugAndroidTest


### PR DESCRIPTION
## Summary
- Renames the workflow's job display names for clarity: `build` -> **Compile Check**, `test` -> **Unit Test**.
- Adds a new **UI Test** job that runs the Kaspresso/Kakao instrumented test added in #4 (`ScreenCheckerActivityTest`), using `reactivecircus/android-emulator-runner` against an `aosp_atd` API 35 image (no Google Play Services needed, since the `screenChecker` module doesn't depend on GMS). Includes the KVM-enable step required for hardware-accelerated emulation on GitHub-hosted Linux runners.

## Test plan
- [x] Verified `./gradlew :screenChecker:connectedDebugAndroidTest` passes locally against a real API 35 emulator
- [ ] Confirm the UI Test job runs green on this PR (first real run on GitHub-hosted infra)

🤖 Generated with [Claude Code](https://claude.com/claude-code)