### PR TITLE
Create a GitHub Release after publishing to Google Play

### DIFF
--- a/.github/workflows/publish-google-play.yml
+++ b/.github/workflows/publish-google-play.yml
@@ -5,6 +5,9 @@ on:
     tags:
       - '*.*.*'
 
+permissions:
+  contents: write
+
 jobs:
   build:
     name: Build AAB
@@ -60,6 +63,8 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v4
+
       - name: Download build output from build job
         uses: actions/download-artifact@v4
         with:
@@ -73,3 +78,9 @@ jobs:
           packageName: app.akexorcist.checkscreen
           track: production
           changesNotSentForReview: true
+
+      - name: Create GitHub Release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASE_TAG: ${{ github.ref_name }}
+        run: gh release create "$RELEASE_TAG" --generate-notes --title "$RELEASE_TAG"


### PR DESCRIPTION
## Summary
- Adds a final step to the `publish` job that runs `gh release create` for the pushed tag with `--generate-notes`, after the Play Store upload succeeds.
- Adds `permissions: contents: write` (needed for `GITHUB_TOKEN` to create releases) and a `checkout` step in `publish` (needed for `gh` to resolve repo context — it previously only downloaded the build artifact).
- Follows the same pattern as `akexorcist/flip-and-fold-counter`'s `release.yml`.

## Test plan
- [x] YAML validated (Ruby's YAML parser)
- [ ] Not tested end-to-end — would require pushing a real release tag, which triggers an actual Play Store upload

🤖 Generated with [Claude Code](https://claude.com/claude-code)