### PR TITLE
Fix release workflow: use JDK 21, matching compileOptions

### DIFF
--- a/.github/workflows/publish-google-play.yml
+++ b/.github/workflows/publish-google-play.yml
@@ -22,10 +22,10 @@ jobs:
             exit 1
           fi
 
-      - name: Set up JDK 17
+      - name: Set up JDK 21
         uses: actions/setup-java@v4
         with:
-          java-version: '17'
+          java-version: '21'
           distribution: 'corretto'
           cache: gradle
 


### PR DESCRIPTION
## Summary
- The release workflow's "Set up JDK" step still used 17, but the SDK 37 migration bumped both modules' `compileOptions` to Java 21. Javac under JDK 17 can't target `--release 21`, so the `2.4.2` release run failed at `:screenChecker:compileReleaseJavaWithJavac` (`invalid source release: 21`) before the AAB was ever built — nothing was uploaded to Play Store or released.
- `pull-request.yml` was already bumped to JDK 21 earlier; this workflow was missed.

## Test plan
- [x] `./gradlew :app:bundleRelease` succeeds locally under JDK 21 with the same `-P` properties the workflow passes
- [x] YAML validated
- [ ] Actual re-run on tag push (once merged, the `2.4.2` tag will need to be deleted and re-pushed to retry the release)

🤖 Generated with [Claude Code](https://claude.com/claude-code)