### PR TITLE
Fix release versionCode offset, move logic to build.gradle.kts

### DIFF
--- a/.github/workflows/publish-google-play.yml
+++ b/.github/workflows/publish-google-play.yml
@@ -46,10 +46,9 @@ jobs:
         run: chmod +x gradlew
 
       - name: Build AAB with Gradle
-        run: |
-          ./gradlew :app:bundleRelease \
-            -PreleaseVersionName="${{ github.ref_name }}" \
-            -PreleaseVersionCode="${{ github.run_number }}"
+        env:
+          RELEASE_VERSION_NAME: ${{ github.ref_name }}
+        run: ./gradlew :app:bundleRelease
 
       - name: Upload AAB to artifactory
         uses: actions/upload-artifact@v4

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -4,9 +4,6 @@ plugins {
     id("com.android.application")
 }
 
-// GITHUB_RUN_NUMBER starts at 1 and has no relation to what's already live on the
-// Play Store; this offset keeps the release workflow's first versionCode safely
-// above the current live versionCode (217 as of 2026-07-28).
 val versionCodeOffset = 217
 val releaseVersionName: String? = System.getenv("RELEASE_VERSION_NAME")
 val releaseRunNumber: String? = System.getenv("GITHUB_RUN_NUMBER")

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -4,6 +4,19 @@ plugins {
     id("com.android.application")
 }
 
+// GITHUB_RUN_NUMBER starts at 1 and has no relation to what's already live on the
+// Play Store; this offset keeps the release workflow's first versionCode safely
+// above the current live versionCode (217 as of 2026-07-28).
+val versionCodeOffset = 217
+val releaseVersionName: String? = System.getenv("RELEASE_VERSION_NAME")
+val releaseRunNumber: String? = System.getenv("GITHUB_RUN_NUMBER")
+
+if (releaseVersionName != null) {
+    require(Regex("""^\d+\.\d+\.\d+$""").matches(releaseVersionName)) {
+        "RELEASE_VERSION_NAME must be in X.Y.Z format, got: $releaseVersionName"
+    }
+}
+
 android {
     namespace = "app.akexorcist.checkscreen"
     compileSdk = 37
@@ -12,8 +25,8 @@ android {
         applicationId = "app.akexorcist.checkscreen"
         minSdk = 21
         targetSdk = 37
-        versionCode = (project.findProperty("releaseVersionCode") as String?)?.toInt() ?: 217
-        versionName = project.findProperty("releaseVersionName") as String? ?: "2.4.1"
+        versionCode = releaseRunNumber?.let { it.toInt() + versionCodeOffset } ?: 217
+        versionName = releaseVersionName ?: "2.4.1"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }


### PR DESCRIPTION
## Summary
- `github.run_number` is scoped to this workflow file, not the app's publishing history — it restarts from 1 even though the last real Play Store versionCode is 217. First real release attempt failed with "Version code 8 has already been used."
- Moved the versionCode/versionName computation into `app/build.gradle.kts`, reading `GITHUB_RUN_NUMBER`/`RELEASE_VERSION_NAME` via `System.getenv()` with a `versionCodeOffset` constant and X.Y.Z format validation — matching the pattern already used in `akexorcist/flip-and-fold-counter`.

## Test plan
- [x] `GITHUB_RUN_NUMBER=8 RELEASE_VERSION_NAME=2.4.2 ./gradlew :app:assembleDebug` → `versionCode=225`, `versionName=2.4.2` (verified via `aapt2 dump badging`)
- [x] No env vars → falls back to `217`/`2.4.1`
- [x] Invalid `RELEASE_VERSION_NAME` fails the build with a clear error

🤖 Generated with [Claude Code](https://claude.com/claude-code)