### PR TITLE
Remove changesNotSentForReview from Play Store upload

### DIFF
--- a/.github/workflows/publish-google-play.yml
+++ b/.github/workflows/publish-google-play.yml
@@ -76,7 +76,6 @@ jobs:
           releaseFiles: bundle/release/app-release.aab
           packageName: app.akexorcist.checkscreen
           track: production
-          changesNotSentForReview: true
 
       - name: Create GitHub Release
         env:


### PR DESCRIPTION
## Summary
- Google's API rejected `changesNotSentForReview: true` for the current release: "Changes are sent for review automatically. The query parameter changesNotSentForReview must not be set." Likely a mandatory review for the first release under the recently reset upload key.
- Removed it for now so the release can go through Google's normal review. Revisit re-adding it for future releases once this one clears.

🤖 Generated with [Claude Code](https://claude.com/claude-code)