### PR TITLE
Merge publish-google-play jobs, drop AAB artifact upload

### DIFF
--- a/.github/workflows/publish-google-play.yml
+++ b/.github/workflows/publish-google-play.yml
@@ -9,8 +9,8 @@ permissions:
   contents: write
 
 jobs:
-  build:
-    name: Build AAB
+  publish:
+    name: Build and Publish to Google Play
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -50,30 +50,11 @@ jobs:
           RELEASE_VERSION_NAME: ${{ github.ref_name }}
         run: ./gradlew :app:bundleRelease
 
-      - name: Upload AAB to artifactory
-        uses: actions/upload-artifact@v4
-        with:
-          name: release-app-bundle
-          path: app/build/outputs/
-          retention-days: 1
-
-  publish:
-    name: Publish to Google Play
-    needs: build
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Download build output from build job
-        uses: actions/download-artifact@v4
-        with:
-          name: release-app-bundle
-
       - name: Upload Android Release to Play Store
         uses: r0adkll/upload-google-play@v1
         with:
           serviceAccountJsonPlainText: ${{secrets.SERVICE_ACCOUNT_JSON}}
-          releaseFiles: bundle/release/app-release.aab
+          releaseFiles: app/build/outputs/bundle/release/app-release.aab
           packageName: app.akexorcist.checkscreen
           track: production
 


### PR DESCRIPTION
## Summary
- Collapses `publish-google-play.yml`'s `build` and `publish` jobs into a single job.
- The two-job split only existed to pass the AAB from `build` to `publish`, which required uploading it via `actions/upload-artifact` (which is why it was showing up under the run's Artifacts tab). A single job builds and publishes straight from the workspace, so that upload is no longer needed.
- Matches the single-job structure already used in `flip-and-fold-counter`'s release workflow.

## Test plan
- [x] YAML validated
- [ ] Verify on a real tag push that the release still publishes to Google Play successfully (can't dry-run a tag-triggered workflow locally)

🤖 Generated with [Claude Code](https://claude.com/claude-code)