### PR TITLE
Skip Pull Request CI checks for workflow-only PRs

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -3,6 +3,8 @@ name: Pull Request
 on:
   pull_request:
     branches: [ "main" ]
+    paths-ignore:
+      - '.github/workflows/**'
 
 jobs:
   compile-check:

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -3,12 +3,30 @@ name: Pull Request
 on:
   pull_request:
     branches: [ "main" ]
-    paths-ignore:
-      - '.github/workflows/**'
 
 jobs:
+  changes:
+    name: Detect Changes
+    runs-on: ubuntu-latest
+    outputs:
+      app: ${{ steps.filter.outputs.app }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Filter changed paths
+        uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          predicate-quantifier: 'every'
+          filters: |
+            app:
+              - '**'
+              - '!.github/workflows/**'
+
   compile-check:
     name: Compile Check
+    needs: changes
+    if: needs.changes.outputs.app == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -28,6 +46,8 @@ jobs:
 
   unit-test:
     name: Unit Test
+    needs: changes
+    if: needs.changes.outputs.app == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -47,6 +67,8 @@ jobs:
 
   ui-test:
     name: UI Test
+    needs: changes
+    if: needs.changes.outputs.app == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## Summary
- Adds a `changes` job (using `dorny/paths-filter`) that detects whether a PR touches anything outside `.github/workflows/**`.
- `compile-check` / `unit-test` / `ui-test` each gain `needs: changes` + `if: needs.changes.outputs.app == 'true'`, so they're skipped when a PR only touches workflow files.

## Why not `paths-ignore` on the trigger?
This repo's branch ruleset requires "Compile Check", "Unit Test", "UI Test" as status checks on `main`. If the workflow never triggers at all (via `paths-ignore`), those three contexts never get reported, and the ruleset leaves the PR stuck in "Pending"/unmergeable forever.

Keeping the workflow triggering on every PR, but skipping the *jobs* via `if:`, avoids that: a skipped job still reports "success" for required-status-check purposes, so:
- **non-CI changes** → jobs run for real, checks must pass as before
- **CI-only changes** (`.github/workflows/**` only) → jobs are skipped, checks still report passing

## Verified
This PR itself only touches `.github/workflows/pull-request.yml`, so it's a live test of the "CI-only" path:
- `Detect Changes` → pass
- `Compile Check` / `Unit Test` / `UI Test` → skipping
- PR merge state: `CLEAN` / `MERGEABLE`

🤖 Generated with [Claude Code](https://claude.com/claude-code)